### PR TITLE
Fix GFX950 MXFP4 import error for triton_kernels compatibility

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -51,9 +51,14 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps):
 
         value_layout = StridedLayout
         if on_gfx950():
-            from triton_kernels.tensor_details.layout import GFX950MXScaleLayout
-
-            scale_layout = GFX950MXScaleLayout
+            try:
+                from triton_kernels.tensor_details.layout import \
+                    GFX950MXScaleLayout
+                scale_layout = GFX950MXScaleLayout
+            except ImportError:
+                from triton_kernels.tensor_details.layout import \
+                    CDNA4MXScaleLayout
+                scale_layout = CDNA4MXScaleLayout
         else:
             scale_layout = StridedLayout
     else:


### PR DESCRIPTION
## Summary
- Fixes `ImportError: cannot import name 'GFX950MXScaleLayout'` when running MXFP4 models (e.g. gpt-oss-120b) on MI350X (GFX950)
- Root cause: `GFX950MXScaleLayout` was renamed to `CDNA4MXScaleLayout` in the vLLM-bundled `triton_kernels` package
- Adds try/except fallback to support both naming conventions

## Test plan
- [x] Verified gpt-oss-120b completion and chat pass on MI350X with this fix
- [ ] Sanity check on MI300X (non-GFX950 path unaffected)